### PR TITLE
prevent ArgumentOutOfRangeException when replacing reversed selection with shorter text

### DIFF
--- a/Tests/ViewModels/CodeEditor/CodeEditorViewModelTests.cs
+++ b/Tests/ViewModels/CodeEditor/CodeEditorViewModelTests.cs
@@ -673,6 +673,41 @@ namespace Jamiras.Core.Tests.ViewModels.CodeEditor
         }
 
         [Test]
+        public void TestReplaceTextWordReverse()
+        {
+            viewModel.MoveCursorTo(1, 19, CodeEditorViewModel.MoveCursorFlags.None);
+            viewModel.MoveCursorTo(1, 6, CodeEditorViewModel.MoveCursorFlags.Highlighting);
+            viewModel.ReplaceSelection("orange");
+
+            Assert.That(viewModel.Lines[0].Text, Is.EqualTo("bool orange(int param1, string param2)"));
+            Assert.That(viewModel.CursorColumn, Is.EqualTo(12));
+        }
+
+        [Test]
+        public void TestUndoReplaceTextWord()
+        {
+            viewModel.MoveCursorTo(1, 6, CodeEditorViewModel.MoveCursorFlags.None);
+            viewModel.MoveCursorTo(1, 19, CodeEditorViewModel.MoveCursorFlags.Highlighting);
+            viewModel.ReplaceSelection("orange");
+            viewModel.HandleKey(Key.Z, ModifierKeys.Control);
+
+            Assert.That(viewModel.Lines[0].Text, Is.EqualTo("bool test_function(int param1, string param2)"));
+            Assert.That(viewModel.CursorColumn, Is.EqualTo(19));
+        }
+
+        [Test]
+        public void TestUndoReplaceTextWordReverse()
+        {
+            viewModel.MoveCursorTo(1, 19, CodeEditorViewModel.MoveCursorFlags.None);
+            viewModel.MoveCursorTo(1, 6, CodeEditorViewModel.MoveCursorFlags.Highlighting);
+            viewModel.ReplaceSelection("orange");
+            viewModel.HandleKey(Key.Z, ModifierKeys.Control);
+
+            Assert.That(viewModel.Lines[0].Text, Is.EqualTo("bool test_function(int param1, string param2)"));
+            Assert.That(viewModel.CursorColumn, Is.EqualTo(6));
+        }
+
+        [Test]
         public void TestReplaceTextWordWithMultipleLines()
         {
             viewModel.MoveCursorTo(1, 6, CodeEditorViewModel.MoveCursorFlags.None);

--- a/ViewModels/CodeEditor/CodeEditorViewModel.cs
+++ b/ViewModels/CodeEditor/CodeEditorViewModel.cs
@@ -1098,6 +1098,9 @@ namespace Jamiras.ViewModels.CodeEditor
                         var text = line.PendingText ?? line.Text;
 
                         var firstChar = (i == orderedSelection.StartLine) ? orderedSelection.StartColumn - 1 : 0;
+                        if (firstChar > text.Length)
+                            firstChar = text.Length;
+
                         int lastChar;
                         if (i == orderedSelection.EndLine)
                         {
@@ -1180,8 +1183,19 @@ namespace Jamiras.ViewModels.CodeEditor
             EndUndo(newText);
 
             var item = _undoStack.Pop();
-            item.After.StartLine = selection.StartLine;
-            item.After.StartColumn = selection.StartColumn;
+
+            if (selection.StartLine > selection.EndLine ||
+                (selection.StartLine == selection.EndLine && selection.StartColumn > selection.EndColumn))
+            {
+                item.After.StartLine = selection.EndLine;
+                item.After.StartColumn = selection.EndColumn;
+            }
+            else
+            {
+                item.After.StartLine = selection.StartLine;
+                item.After.StartColumn = selection.StartColumn;
+            }
+
             _undoStack.Push(item);
 
             Refresh();


### PR DESCRIPTION
I believe this addresses the remaining exception in https://github.com/Jamiras/RATools/issues/23.

Steps to reproduce:
1) Place some smaller amount of text on the clipboard: `byte(0x1234) == 0`
2) Highlight a larger amount of text starting from the end of the selection (i.e. the `byte(0x1234 == 1 && byte(0x2345) == 2` below starting from the 2 and ending with the leftmost byte).
```
achievement("Title", "Description", 5, 
    trigger = byte(0x1234) == 1 && byte(0x2345) == 2
)
```
3) Paste the smaller text
4) Undo

Both steps 3 and 4 cause ArgumentOutOfRange exceptions because the start of the selection is at a column that no longer exists. 

I've updated the logic for building and restoring the Undo buffer to better handle a reversed selection.