### PR TITLE
when replacing multiple lines, use PendingText for intermediary lines

### DIFF
--- a/ViewModels/CodeEditor/CodeEditorViewModel.cs
+++ b/ViewModels/CodeEditor/CodeEditorViewModel.cs
@@ -1295,7 +1295,7 @@ namespace Jamiras.ViewModels.CodeEditor
 
             for (int i = 1; i < newTextLines.Length - 1; i++)
             {
-                line = new LineViewModel(this, selection.StartLine + i) { Text = newTextLines[i].TrimEnd('\r') };
+                line = new LineViewModel(this, selection.StartLine + i) { PendingText = newTextLines[i].TrimEnd('\r') };
                 _lines.Insert(selection.StartLine + i - 1, line);
                 linesAdded++;
             }


### PR DESCRIPTION
fixes https://github.com/Jamiras/RATools/issues/28

When replacing multiple lines with multiple lines, only the first and last line were being treated as modified as the other lines are completely removed and re-inserted, so there's nothing to compare against. As long as the first and last line are unchanged, the editor doesn't trigger a recompile.

I've modified the logic to create the intermediary lines in such a way that they're always considered modified. Pasting multiline text over the exact same block of existing text will now trigger a recompile, where it didn't before. But that's an acceptable tradeoff for fixing the reported issue.