### PR TITLE
don't expose LineViewModel through LineEventArgs

### DIFF
--- a/Source/ViewModels/CodeEditor/LineEventArgs.cs
+++ b/Source/ViewModels/CodeEditor/LineEventArgs.cs
@@ -19,9 +19,17 @@ namespace Jamiras.ViewModels.CodeEditor
         }
 
         /// <summary>
+        /// Gets the line number for the associated line.
+        /// </summary>
+        public int LineNumber
+        {
+            get { return Line.Line; }
+        }
+
+        /// <summary>
         /// Gets the associated line.
         /// </summary>
-        public LineViewModel Line { get; private set; }
+        internal LineViewModel Line { get; private set; }
 
         /// <summary>
         /// Gets the current text for the associated line.


### PR DESCRIPTION
ensures users access the `Text` property of the `LineEventArgs` instead of the `Text` property of the `LineViewModel` to prevent issues around `PendingText`.