### PR TITLE
coerce boolean value from integer JSON fields

### DIFF
--- a/Core/Source/IO/Serialization/JsonObject.cs
+++ b/Core/Source/IO/Serialization/JsonObject.cs
@@ -733,6 +733,9 @@ namespace Jamiras.IO.Serialization
                 if (_value is bool)
                     return (bool)_value;
 
+                if (_value is int)
+                    return (int)_value != 0;
+
                 return false;
             }
         }

--- a/Core/Tests/IO/Serialization/JsonObjectTests.cs
+++ b/Core/Tests/IO/Serialization/JsonObjectTests.cs
@@ -82,6 +82,26 @@ namespace Jamiras.Core.Tests.IO.Serialization
         }
 
         [Test]
+        public void TestTrueFromIntegerField()
+        {
+            var o = new JsonObject("{ \"foo\" : 1 }");
+            Assert.That(o.GetField("foo").Type, Is.EqualTo(JsonFieldType.Integer));
+            Assert.That(o.GetField("foo").BooleanValue, Is.True);
+
+            o = new JsonObject("{ \"foo\" : 99 }");
+            Assert.That(o.GetField("foo").Type, Is.EqualTo(JsonFieldType.Integer));
+            Assert.That(o.GetField("foo").BooleanValue, Is.True);
+        }
+
+        [Test]
+        public void TestFalseFromIntegerField()
+        {
+            var o = new JsonObject("{ \"foo\" : 0 }");
+            Assert.That(o.GetField("foo").Type, Is.EqualTo(JsonFieldType.Integer));
+            Assert.That(o.GetField("foo").BooleanValue, Is.False);
+        }
+
+        [Test]
         public void TestNullField()
         {
             var o = new JsonObject("{ \"foo\" : null }");


### PR DESCRIPTION
Allows reading boolean from JsonObject integer field, where any non-zero value is assumed to be true:
*  `{ "f" : 1 }` => true
*  `{ "f" : 0 }` => false
*  `{ "f" : 99 }` => true
