### PR TITLE
add Tokenizer.ReadWord

### DIFF
--- a/Core/Source/Components/Tokenizer.cs
+++ b/Core/Source/Components/Tokenizer.cs
@@ -414,6 +414,19 @@ namespace Jamiras.Components
         }
 
         /// <summary>
+        /// Matches a token containing alphabetic characters.
+        /// </summary>
+        public Token ReadWord()
+        {
+            StartToken();
+
+            while (Char.IsLetter(NextChar))
+                Advance();
+
+            return EndToken();
+        }
+
+        /// <summary>
         /// Matches a token containing alphanumeric characters and/or underscores.
         /// </summary>
         public Token ReadIdentifier()

--- a/Core/Tests/Components/TokenizerTests.cs
+++ b/Core/Tests/Components/TokenizerTests.cs
@@ -154,6 +154,24 @@ namespace Jamiras.Core.Tests.Components
         }
 
         [Test]
+        public void TestReadWord()
+        {
+            var tokenizer = CreateTokenizer("Hello, world!");
+            var token = tokenizer.ReadWord();
+            Assert.That(token.ToString(), Is.EqualTo("Hello"));
+            Assert.That(tokenizer.NextChar, Is.EqualTo(','));
+        }
+
+        [Test]
+        public void TestReadWordIdentifier()
+        {
+            var tokenizer = CreateTokenizer("redSquare2();");
+            var token = tokenizer.ReadWord();
+            Assert.That(token.ToString(), Is.EqualTo("redSquare"));
+            Assert.That(tokenizer.NextChar, Is.EqualTo('2'));
+        }
+
+        [Test]
         [TestCase(false)]
         [TestCase(true)]
         public void TestReadNumberInteger(bool useStream)


### PR DESCRIPTION
Similar to `Tokenizer.ReadIdentifier` but only allows alphabetic characters (not alphanumeric).